### PR TITLE
teste-[PCO-1144] Retirada bloqueio o

### DIFF
--- a/jira-task-manager
+++ b/jira-task-manager
@@ -15,6 +15,7 @@ RES='\e[0m'     # RESET ALL
 LNK='\e]8;;'    # LINK
 
 
+
 ### FUNÇÃO QUE EXIBE O HELP
 function showHelp {
   clear


### PR DESCRIPTION
O "bloqueio o" √© um bloqueio de preven√ß√£o a fraude que cliente n√£o deveria ter permiss√£o de retira-lo pelo aplicativo. Por regra, retirada desse bloqueio √© permitida apenas por meio de central de atendimento ap√≥s valida√ß√£o de identidade.
√â preciso garantir que o cliente n√£o consiga retirar esse bloqueio pelo fluxo de desbloqueio de cart√£o atual, seja sele por:
- Push do desbloqueio;
- QR de desbloqueio;
- Demais comunica√ß√µes que direcionam para o fluxo de desbloqueio de cart√£o.

Caso de cliente que conseguiu retirar o bloqueio o com a leitura de qr code: consumer 14418200 em 10/03/2021.
