### PR TITLE
teste-[PCO-1144] Retirada bloqueio o

### DIFF
--- a/jira-task-manager
+++ b/jira-task-manager
@@ -15,7 +15,6 @@ RES='\e[0m'     # RESET ALL
 LNK='\e]8;;'    # LINK
 
 
-
 ### FUNÇÃO QUE EXIBE O HELP
 function showHelp {
   clear


### PR DESCRIPTION
O "bloqueio o" é um bloqueio de prevenção a fraude que cliente não deveria ter permissão de retira-lo pelo aplicativo. Por regra, retirada desse bloqueio é permitida apenas por meio de central de atendimento após validação de identidade.
É preciso garantir que o cliente não consiga retirar esse bloqueio pelo fluxo de desbloqueio de cartão atual, seja sele por:
- Push do desbloqueio;
- QR de desbloqueio;
- Demais comunicações que direcionam para o fluxo de desbloqueio de cartão.

Caso de cliente que conseguiu retirar o bloqueio o com a leitura de qr code: consumer 14418200 em 10/03/2021.
